### PR TITLE
Expose raw CPE version ranges for advisory tooling

### DIFF
--- a/src/main/java/org/midnightbsd/advisory/ctl/api/CpeController.java
+++ b/src/main/java/org/midnightbsd/advisory/ctl/api/CpeController.java
@@ -3,6 +3,7 @@ package org.midnightbsd.advisory.ctl.api;
 import java.util.Date;
 import java.util.List;
 import org.midnightbsd.advisory.dto.AdvisoryDto;
+import org.midnightbsd.advisory.dto.CpeRangeAdvisoryDto;
 import org.midnightbsd.advisory.services.AdvisoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -49,6 +50,28 @@ public class CpeController {
                 parsed.getVersion(),
                 startDate,
                 Boolean.TRUE.equals(includeVersion)));
+  }
+
+  @GetMapping("ranges")
+  public ResponseEntity<List<CpeRangeAdvisoryDto>> ranges(
+      @RequestParam(name = "cpe") String cpe,
+      @RequestParam(required = false, name = "startDate")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          Date startDate) {
+    final String cleanedCpe = cpe.trim();
+    if (!StringUtils.hasText(cleanedCpe)) {
+      return ResponseEntity.badRequest().build();
+    }
+
+    final Cpe parsed;
+    try {
+      parsed = parse(cleanedCpe);
+    } catch (final CpeParsingException ex) {
+      return ResponseEntity.badRequest().build();
+    }
+
+    return ResponseEntity.ok(
+        advisoryService.cpeRangeDtos(parsed.getVendor(), parsed.getProduct(), startDate));
   }
 
   Cpe parse(String cpe) throws CpeParsingException {

--- a/src/main/java/org/midnightbsd/advisory/dto/CpeConfigurationDto.java
+++ b/src/main/java/org/midnightbsd/advisory/dto/CpeConfigurationDto.java
@@ -1,0 +1,6 @@
+package org.midnightbsd.advisory.dto;
+
+import java.util.List;
+
+public record CpeConfigurationDto(
+    int id, Integer parentId, String operator, Boolean negate, List<CpeRangeDto> matches) {}

--- a/src/main/java/org/midnightbsd/advisory/dto/CpeRangeAdvisoryDto.java
+++ b/src/main/java/org/midnightbsd/advisory/dto/CpeRangeAdvisoryDto.java
@@ -1,0 +1,29 @@
+package org.midnightbsd.advisory.dto;
+
+import java.util.Date;
+import java.util.List;
+import org.midnightbsd.advisory.model.Advisory;
+
+public record CpeRangeAdvisoryDto(
+    int id,
+    String cveId,
+    String description,
+    Date publishedDate,
+    Date lastModifiedDate,
+    String severity,
+    String problemType,
+    List<CpeConfigurationDto> configurations) {
+
+  public static CpeRangeAdvisoryDto from(
+      Advisory advisory, List<CpeConfigurationDto> configurations) {
+    return new CpeRangeAdvisoryDto(
+        advisory.getId(),
+        advisory.getCveId(),
+        advisory.getDescription(),
+        advisory.getPublishedDate(),
+        advisory.getLastModifiedDate(),
+        advisory.getSeverity(),
+        advisory.getProblemType(),
+        configurations);
+  }
+}

--- a/src/main/java/org/midnightbsd/advisory/dto/CpeRangeDto.java
+++ b/src/main/java/org/midnightbsd/advisory/dto/CpeRangeDto.java
@@ -1,0 +1,24 @@
+package org.midnightbsd.advisory.dto;
+
+import org.midnightbsd.advisory.model.ConfigNodeCpe;
+
+public record CpeRangeDto(
+    String criteria,
+    Boolean vulnerable,
+    String matchCriteriaId,
+    String versionStartIncluding,
+    String versionStartExcluding,
+    String versionEndIncluding,
+    String versionEndExcluding) {
+
+  public static CpeRangeDto from(ConfigNodeCpe cpe) {
+    return new CpeRangeDto(
+        cpe.getCpe23Uri(),
+        cpe.getVulnerable(),
+        cpe.getMatchCriteriaId(),
+        cpe.getVersionStartIncluding(),
+        cpe.getVersionStartExcluding(),
+        cpe.getVersionEndIncluding(),
+        cpe.getVersionEndExcluding());
+  }
+}

--- a/src/main/java/org/midnightbsd/advisory/services/AdvisoryService.java
+++ b/src/main/java/org/midnightbsd/advisory/services/AdvisoryService.java
@@ -242,6 +242,7 @@ public class AdvisoryService implements AppService<Advisory> {
     return advisories;
   }
 
+  @Transactional(readOnly = true)
   public List<CpeRangeAdvisoryDto> cpeRangeDtos(
       final String vendorName, final String productName, final Date startDate) {
     return getByVendorAndProduct(vendorName, productName, startDate).stream()

--- a/src/main/java/org/midnightbsd/advisory/services/AdvisoryService.java
+++ b/src/main/java/org/midnightbsd/advisory/services/AdvisoryService.java
@@ -39,6 +39,9 @@ import java.util.concurrent.ConcurrentMap;
 
 import lombok.extern.slf4j.Slf4j;
 import org.midnightbsd.advisory.dto.AdvisoryDto;
+import org.midnightbsd.advisory.dto.CpeConfigurationDto;
+import org.midnightbsd.advisory.dto.CpeRangeAdvisoryDto;
+import org.midnightbsd.advisory.dto.CpeRangeDto;
 import org.midnightbsd.advisory.model.Advisory;
 import org.midnightbsd.advisory.model.Product;
 import org.midnightbsd.advisory.model.Vendor;
@@ -237,6 +240,67 @@ public class AdvisoryService implements AppService<Advisory> {
               List.copyOf(advisories), now + CPE_MATCH_CACHE_TTL.toMillis()));
     }
     return advisories;
+  }
+
+  public List<CpeRangeAdvisoryDto> cpeRangeDtos(
+      final String vendorName, final String productName, final Date startDate) {
+    return getByVendorAndProduct(vendorName, productName, startDate).stream()
+        .map(advisory -> cpeRangeDto(advisory, vendorName, productName))
+        .filter(Objects::nonNull)
+        .toList();
+  }
+
+  private CpeRangeAdvisoryDto cpeRangeDto(
+      final Advisory advisory, final String vendorName, final String productName) {
+    if (advisory.getConfigNodes() == null) {
+      return null;
+    }
+
+    final boolean hasMatchingProduct =
+        advisory.getConfigNodes().stream()
+            .filter(node -> node.getConfigNodeCpes() != null)
+            .flatMap(node -> node.getConfigNodeCpes().stream())
+            .anyMatch(cpe -> matchesProduct(cpe.getCpe23Uri(), vendorName, productName));
+    if (!hasMatchingProduct) {
+      return null;
+    }
+
+    final List<CpeConfigurationDto> configurations =
+        advisory.getConfigNodes().stream()
+            .sorted(java.util.Comparator.comparingInt(node -> node.getId()))
+            .map(
+                node ->
+                    new CpeConfigurationDto(
+                        node.getId(),
+                        node.getParentId(),
+                        node.getOperator(),
+                        node.getNegate(),
+                        node.getConfigNodeCpes() == null
+                            ? List.of()
+                            : node.getConfigNodeCpes().stream()
+                                .map(CpeRangeDto::from)
+                                .sorted(
+                                    java.util.Comparator.comparing(
+                                        CpeRangeDto::criteria,
+                                        java.util.Comparator.nullsLast(String::compareTo)))
+                                .toList()))
+            .toList();
+
+    return configurations.isEmpty()
+        ? null
+        : CpeRangeAdvisoryDto.from(advisory, configurations);
+  }
+
+  private boolean matchesProduct(
+      final String criteria, final String vendorName, final String productName) {
+    try {
+      final Cpe parsed = CpeParser.parse(criteria);
+      return parsed.getVendor().equalsIgnoreCase(vendorName)
+          && parsed.getProduct().equalsIgnoreCase(productName);
+    } catch (Exception ex) {
+      log.warn("Unable to parse CPE23 URI while building range response: {}", criteria);
+      return false;
+    }
   }
 
   private List<List<Product>> getProducts(final String vendorName, final String productName) {

--- a/src/main/java/org/midnightbsd/advisory/services/AdvisoryService.java
+++ b/src/main/java/org/midnightbsd/advisory/services/AdvisoryService.java
@@ -294,12 +294,15 @@ public class AdvisoryService implements AppService<Advisory> {
 
   private boolean matchesProduct(
       final String criteria, final String vendorName, final String productName) {
+    if (!StringUtils.hasText(criteria)) {
+      return false;
+    }
     try {
       final Cpe parsed = CpeParser.parse(criteria);
       return parsed.getVendor().equalsIgnoreCase(vendorName)
           && parsed.getProduct().equalsIgnoreCase(productName);
     } catch (Exception ex) {
-      log.warn("Unable to parse CPE23 URI while building range response: {}", criteria);
+      log.warn("Unable to parse CPE23 URI while building range response: {}", criteria, ex);
       return false;
     }
   }

--- a/src/test/java/org/midnightbsd/advisory/ctl/CpeControllerTest.java
+++ b/src/test/java/org/midnightbsd/advisory/ctl/CpeControllerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.midnightbsd.advisory.ctl.api.CpeController;
 import org.midnightbsd.advisory.dto.AdvisoryDto;
+import org.midnightbsd.advisory.dto.CpeRangeAdvisoryDto;
 import org.midnightbsd.advisory.model.Advisory;
 import org.midnightbsd.advisory.services.AdvisoryService;
 import org.mockito.ArgumentMatchers;
@@ -90,6 +91,18 @@ class CpeControllerTest {
                 .thenReturn(List.of(AdvisoryDto.from(adv)));
         mockMvc
                 .perform(get("/api/cpe/partial-match?cpe=cpe:2.3:a:eric_allman:sendmail:5.58:*:*:*:*:*:*:*&includeVersion=true"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json;charset=UTF-8"));
+    }
+
+    @Test
+    void mvcTestGetCpeRanges() throws Exception {
+        when(advisoryService.cpeRangeDtos(anyString(), anyString(), ArgumentMatchers.isNull()))
+                .thenReturn(List.of(new CpeRangeAdvisoryDto(
+                        1, TEST_CVE_ID, "TEST ARCH", null, null, "HIGH", null, List.of())));
+
+        mockMvc
+                .perform(get("/api/cpe/ranges?cpe=cpe:2.3:a:eric_allman:sendmail:5.58:*:*:*:*:*:*:*"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("application/json;charset=UTF-8"));
     }

--- a/src/test/java/org/midnightbsd/advisory/services/AdvisoryServiceTest.java
+++ b/src/test/java/org/midnightbsd/advisory/services/AdvisoryServiceTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.midnightbsd.advisory.dto.AdvisoryDto;
+import org.midnightbsd.advisory.dto.CpeRangeAdvisoryDto;
 import org.midnightbsd.advisory.model.*;
 import org.midnightbsd.advisory.repository.AdvisoryRepository;
 import org.midnightbsd.advisory.repository.ProductRepository;
@@ -239,6 +240,43 @@ class AdvisoryServiceTest {
     verify(vendorRepository, times(1)).findOneByName("vendor");
     verify(productRepository, times(1)).findByNameAndVendor("product", vendor);
     verify(advisoryRepository, times(1)).findByProductsIn(anyList());
+  }
+
+  @Test
+  void cpeRangeDtosPreservesNvdRangeConstraints() {
+    var vendor = new Vendor();
+    vendor.setName("vendor");
+    var product = new Product();
+    product.setName("product");
+    product.setVendor(vendor);
+    ConfigNodeCpe cpe = adv.getConfigNodes().iterator().next().getConfigNodeCpes().iterator().next();
+    cpe.setVersionStartIncluding("1.0");
+    cpe.setVersionEndExcluding("2.0");
+    ConfigNode matchingNode = adv.getConfigNodes().iterator().next();
+    matchingNode.setParentId(2);
+    ConfigNode parentNode = new ConfigNode();
+    parentNode.setId(2);
+    parentNode.setOperator("AND");
+    parentNode.setConfigNodeCpes(Collections.emptySet());
+    adv.setConfigNodes(new HashSet<>(Set.of(matchingNode, parentNode)));
+
+    when(vendorRepository.findOneByName("vendor")).thenReturn(vendor);
+    when(productRepository.findByNameAndVendor("product", vendor)).thenReturn(List.of(product));
+    when(advisoryRepository.findByProductsIn(anyList())).thenReturn(List.of(adv));
+
+    List<CpeRangeAdvisoryDto> results =
+        advisoryService.cpeRangeDtos("vendor", "product", null);
+
+    assertEquals(1, results.size());
+    assertEquals("CVE-0000-0000", results.get(0).cveId());
+    assertEquals("OR", results.get(0).configurations().get(0).operator());
+    assertEquals(
+        "1.0", results.get(0).configurations().get(0).matches().get(0).versionStartIncluding());
+    assertEquals(
+        "2.0", results.get(0).configurations().get(0).matches().get(0).versionEndExcluding());
+    assertEquals(2, results.get(0).configurations().size());
+    assertEquals("AND", results.get(0).configurations().get(1).operator());
+    assertTrue(results.get(0).configurations().get(1).matches().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## What changed

- add `GET /api/cpe/ranges`
- return advisory metadata together with raw NVD CPE match constraints
- preserve configuration node hierarchy, operators, negation, parent IDs, and inclusive/exclusive version boundaries
- add controller and service coverage

## Why

The existing version-matching endpoint reduces advisory data to a yes/no match. MidnightBSD's VuXML generator needs the original NVD boundaries so it can translate them into ranges using MidnightBSD package versions, revisions, and epochs instead of assuming FreeBSD package versions match.

## Validation

- full Maven test suite: 101 tests, 0 failures
- focused controller and advisory service tests
- `git diff --check`

Tests were run with Java 21 in interpreted mode on MidnightBSD. JaCoCo was skipped because its agent triggers a host JVM JIT crash. Spotless was not run because the repository's existing google-java-format version is incompatible with the available JDK compiler APIs.

## Summary by Sourcery

Add an API endpoint to expose raw NVD CPE configuration ranges for advisories and wire it through the advisory service and controller.

New Features:
- Introduce CpeRangeAdvisoryDto, CpeConfigurationDto, and CpeRangeDto to represent advisories with associated NVD CPE configuration and version range metadata.
- Expose GET /api/cpe/ranges to return advisories and their CPE configuration hierarchies for a given CPE identifier.

Enhancements:
- Extend AdvisoryService to build and return CPE range advisory DTOs while preserving configuration hierarchy and version boundary information.

Tests:
- Add service- and controller-level tests to verify CPE range DTO construction and the /api/cpe/ranges endpoint response.